### PR TITLE
Support new protocols in clash generation

### DIFF
--- a/tests/test_aggregator_clash_proxy.py
+++ b/tests/test_aggregator_clash_proxy.py
@@ -11,6 +11,9 @@ def test_aggregator_clash_proxy(tmp_path):
     configs = [
         "reality://uuid@host:443?flow=xtls-rprx-vision",
         "naive://user:pass@host:443",
+        "shadowtls://host:8443",
+        "brook://user@host:8080",
+        "juicity://pass@host:5555",
     ]
     aggregator_tool.output_files(configs, tmp_path, cfg)
     data = yaml.safe_load((tmp_path / "clash.yaml").read_text())
@@ -19,3 +22,6 @@ def test_aggregator_clash_proxy(tmp_path):
     assert reality["tls"] is True
     naive = next(p for p in data["proxies"] if p["type"] == "http")
     assert naive["tls"] is True
+    assert any(p["type"] == "shadowtls" for p in data["proxies"])
+    assert any(p["type"] == "brook" for p in data["proxies"])
+    assert any(p["type"] == "juicity" for p in data["proxies"])

--- a/tests/test_clash_proxies_yaml.py
+++ b/tests/test_clash_proxies_yaml.py
@@ -48,14 +48,41 @@ def test_clash_proxies_yaml(tmp_path, monkeypatch):
         is_reachable=True,
         source_url="s",
     )
-    results = [res1, res2, res3, res4]
+    res5 = ConfigResult(
+        config="shadowtls://host:443",
+        protocol="ShadowTLS",
+        host="host",
+        port=443,
+        ping_time=0.5,
+        is_reachable=True,
+        source_url="s",
+    )
+    res6 = ConfigResult(
+        config="brook://user@host:8080",
+        protocol="Brook",
+        host="host",
+        port=8080,
+        ping_time=0.6,
+        is_reachable=True,
+        source_url="s",
+    )
+    res7 = ConfigResult(
+        config="juicity://pass@host:5555",
+        protocol="Juicity",
+        host="host",
+        port=5555,
+        ping_time=0.7,
+        is_reachable=True,
+        source_url="s",
+    )
+    results = [res1, res2, res3, res4, res5, res6, res7]
     stats = merger._analyze_results(results, [])
     asyncio.run(merger._generate_comprehensive_outputs(results, stats, 0.0))
     path = tmp_path / "vpn_clash_proxies.yaml"
     assert path.exists()
     data = yaml.safe_load(path.read_text())
     assert "proxies" in data
-    assert len(data["proxies"]) == 4
+    assert len(data["proxies"]) == 7
     naive = next(p for p in data["proxies"] if p["type"] == "http")
     assert naive["username"] == "user"
     assert naive["password"] == "pass"
@@ -63,3 +90,6 @@ def test_clash_proxies_yaml(tmp_path, monkeypatch):
     reality = next(p for p in data["proxies"] if p.get("flow"))
     assert reality["type"] == "vless"
     assert reality["tls"] is True
+    assert any(p["type"] == "shadowtls" for p in data["proxies"])
+    assert any(p["type"] == "brook" for p in data["proxies"])
+    assert any(p["type"] == "juicity" for p in data["proxies"])

--- a/tests/test_valid_config.py
+++ b/tests/test_valid_config.py
@@ -50,3 +50,18 @@ def test_ssr_with_fragment():
     b64 = base64.urlsafe_b64encode(raw.encode()).decode().strip("=")
     link = f"ssr://{b64}#note"
     assert is_valid_config(link)
+
+
+def test_shadowtls_basic_format():
+    link = "shadowtls://example.com:443"
+    assert is_valid_config(link)
+
+
+def test_brook_basic_format():
+    link = "brook://user@example.com:8080"
+    assert is_valid_config(link)
+
+
+def test_juicity_basic_format():
+    link = "juicity://pass@example.com:4443"
+    assert is_valid_config(link)

--- a/vpn_merger.py
+++ b/vpn_merger.py
@@ -1163,6 +1163,38 @@ class UltimateVPNMerger:
                     "password": p.password or "",
                     "tls": True,
                 }
+            elif scheme == "juicity":
+                p = urlparse(config)
+                if not p.hostname or not p.port:
+                    return None
+                return {
+                    "name": p.fragment or name,
+                    "type": "juicity",
+                    "server": p.hostname,
+                    "port": p.port,
+                    "password": p.username or p.password or "",
+                }
+            elif scheme == "brook":
+                p = urlparse(config)
+                if not p.hostname or not p.port:
+                    return None
+                return {
+                    "name": p.fragment or name,
+                    "type": "brook",
+                    "server": p.hostname,
+                    "port": p.port,
+                    "username": p.username or "",
+                }
+            elif scheme == "shadowtls":
+                p = urlparse(config)
+                if not p.hostname or not p.port:
+                    return None
+                return {
+                    "name": p.fragment or name,
+                    "type": "shadowtls",
+                    "server": p.hostname,
+                    "port": p.port,
+                }
             else:
                 p = urlparse(config)
                 if not p.hostname or not p.port:


### PR DESCRIPTION
## Summary
- extend protocol regex list and validation checks
- handle juicity, brook and shadowtls protocols when exporting clash proxies
- update `UltimateVPNMerger` with the same logic
- test new schemes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687225c3076c8326a2580055b6cb28be