### PR TITLE
Add source failure tracking and no-prune flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Unit tests for configuration parsing and deduplication.
 - Improved Telegram configuration handling.
 
+## [0.5.0] - 2025-07-13
+### Added
+- Failure tracking for aggregator sources. Entries are only pruned after three consecutive failures.
+- `--no-prune` flag to disable automatic pruning.
+
 ## [0.3.0] - 2025-07-12
 ### Added
 - Continuous integration workflow on GitHub Actions.

--- a/README.md
+++ b/README.md
@@ -595,7 +595,10 @@ It also outputs a `clash.yaml` file that works in both Clash and Clash Meta.
    starting with `vmess`, `vless`, `trojan`, `ss`,
    `ssr`, `hysteria`, `hysteria2`, `tuic`, `reality`, `naive`, `hy2` and
    `wireguard`.
-4. Run the tool. The `--hours` option controls how many hours of channel history
+4. Dead sources are only removed after three consecutive failures. The
+   `sources.txt` companion file `sources.fails.json` tracks these counts. Pass
+   `--no-prune` to keep the list intact regardless of failures.
+5. Run the tool. The `--hours` option controls how many hours of channel history
    are scanned (default is 24). Use `--no-base64`, `--no-singbox` or
    `--no-clash` to skip optional outputs:
    ```bash
@@ -666,7 +669,7 @@ Optional fields use these defaults when omitted:
 
 The command line options `--config`, `--sources`, `--channels`, `--output-dir`,
 `--concurrent-limit`, `--request-timeout`, `--hours`, `--no-base64`,
-`--no-singbox` and `--no-clash` let you override file locations or disable
+`--no-singbox`, `--no-clash` and `--no-prune` let you override file locations or disable
 specific outputs when running the tool.
 
 ### Important Notes


### PR DESCRIPTION
## Summary
- keep a JSON file of consecutive failures in `check_and_update_sources`
- add `--no-prune` CLI flag
- document pruning behaviour and CLI option
- update tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68722516a2c883269a3bcbf76c18715c