### PR TITLE
Add aiohttp-based fetch pipeline tests

### DIFF
--- a/tests/test_fetch_pipeline.py
+++ b/tests/test_fetch_pipeline.py
@@ -1,0 +1,49 @@
+import asyncio
+import os
+import sys
+from aiohttp import web
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import aggregator_tool
+
+pytest_plugins = "aiohttp.pytest_plugin"
+
+
+@pytest.mark.asyncio
+async def test_fetch_and_parse_configs_mixed(aiohttp_client):
+    async def good1(request):
+        return web.Response(text="vmess://good1")
+
+    async def good2(request):
+        encoded = "vmess://good2".encode()
+        return web.Response(body=encoded)
+
+    async def empty(request):
+        return web.Response(text="")
+
+    async def bad(request):
+        return web.Response(status=500)
+
+    async def slow(request):
+        await asyncio.sleep(0.05)
+        return web.Response(text="vmess://slow")
+
+    app = web.Application()
+    app.router.add_get("/good1", good1)
+    app.router.add_get("/good2", good2)
+    app.router.add_get("/empty", empty)
+    app.router.add_get("/bad", bad)
+    app.router.add_get("/slow", slow)
+    client = await aiohttp_client(app)
+
+    urls = [
+        client.make_url("/good1"),
+        client.make_url("/good2"),
+        client.make_url("/empty"),
+        client.make_url("/bad"),
+        client.make_url("/slow"),
+    ]
+
+    configs = await aggregator_tool.fetch_and_parse_configs(urls, max_concurrent=3, request_timeout=0.01)
+    assert configs == {"vmess://good1", "vmess://good2"}

--- a/tests/test_fetch_text.py
+++ b/tests/test_fetch_text.py
@@ -1,0 +1,46 @@
+import asyncio
+import os
+import sys
+from aiohttp import web, ClientSession
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import aggregator_tool
+
+pytest_plugins = "aiohttp.pytest_plugin"
+
+
+@pytest.mark.asyncio
+async def test_fetch_text_http_codes(aiohttp_client):
+    async def ok(request):
+        return web.Response(text="hi")
+
+    async def not_found(request):
+        return web.Response(status=404)
+
+    app = web.Application()
+    app.router.add_get("/ok", ok)
+    app.router.add_get("/nf", not_found)
+    client = await aiohttp_client(app)
+
+    async with ClientSession() as session:
+        text = await aggregator_tool.fetch_text(session, client.make_url("/ok"))
+        assert text == "hi"
+
+        text2 = await aggregator_tool.fetch_text(session, client.make_url("/nf"))
+        assert text2 is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_text_timeout(aiohttp_client):
+    async def slow(request):
+        await asyncio.sleep(0.05)
+        return web.Response(text="late")
+
+    app = web.Application()
+    app.router.add_get("/slow", slow)
+    client = await aiohttp_client(app)
+
+    async with ClientSession() as session:
+        text = await aggregator_tool.fetch_text(session, client.make_url("/slow"), timeout=0.01)
+        assert text is None

--- a/tests/test_maybe_save_batch.py
+++ b/tests/test_maybe_save_batch.py
@@ -4,6 +4,7 @@ import asyncio
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from vpn_merger import UltimateVPNMerger, ConfigResult, CONFIG
+import pytest
 
 
 def test_maybe_save_batch_strict_cumulative(monkeypatch, tmp_path):
@@ -34,3 +35,41 @@ def test_maybe_save_batch_strict_cumulative(monkeypatch, tmp_path):
     asyncio.run(asyncio.wait_for(merger._maybe_save_batch(), 0.5))
 
     assert merger.last_saved_count == len(merger.cumulative_unique)
+
+
+@pytest.mark.asyncio
+async def test_maybe_save_batch_concurrent(monkeypatch, tmp_path):
+    monkeypatch.setattr(CONFIG, "batch_size", 1)
+    monkeypatch.setattr(CONFIG, "strict_batch", False)
+    monkeypatch.setattr(CONFIG, "cumulative_batches", True)
+    monkeypatch.setattr(CONFIG, "enable_sorting", False)
+    monkeypatch.setattr(CONFIG, "output_dir", str(tmp_path))
+
+    merger = UltimateVPNMerger()
+
+    async def dummy_generate(*_a, **_k):
+        await asyncio.sleep(0)
+
+    monkeypatch.setattr(UltimateVPNMerger, "_generate_comprehensive_outputs", dummy_generate)
+    monkeypatch.setattr(UltimateVPNMerger, "_analyze_results", lambda self, r, s: {})
+
+    def make_result(idx: int) -> ConfigResult:
+        return ConfigResult(
+            config=f"vmess://{idx}",
+            protocol="VMess",
+            host="h",
+            port=80,
+            ping_time=0.1,
+            is_reachable=True,
+            source_url=f"src{idx}",
+        )
+
+    async def worker(res: ConfigResult):
+        merger.all_results.append(res)
+        await merger._maybe_save_batch()
+
+    tasks = [worker(make_result(i)) for i in range(5)]
+    await asyncio.gather(*tasks)
+
+    assert len(merger.cumulative_unique) == 5
+


### PR DESCRIPTION
## Summary
- add tests for fetch_text HTTP codes and timeouts
- cover fetch_and_parse_configs with mixed success and failure sources
- stress _maybe_save_batch with concurrent calls

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872ee7f6c0483269d1840a72d16e9da